### PR TITLE
Upgrade to Swift 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
 ```
 
 ## Requirements
-Swift 3
+Swift 5
 
 ## Contribute
 

--- a/SwiftIpfsApi.xcodeproj/project.pbxproj
+++ b/SwiftIpfsApi.xcodeproj/project.pbxproj
@@ -227,16 +227,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0710;
-				LastUpgradeCheck = 0930;
+				LastUpgradeCheck = 1130;
 				ORGANIZATIONNAME = "Teo Sartori";
 				TargetAttributes = {
 					AB0A3AAC1BD6705B0090C97A = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1130;
 					};
 					AB0A3AB61BD6705B0090C97A = {
 						CreatedOnToolsVersion = 7.1;
-						LastSwiftMigration = 0920;
+						LastSwiftMigration = 1130;
 					};
 				};
 			};
@@ -245,6 +245,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = AB0A3AA31BD6705B0090C97A;
@@ -504,7 +505,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -531,7 +532,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -549,7 +550,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "Terminal-Glow.SwiftIpfsApiTests";
 				PRODUCT_NAME = SwiftIpfsApiTests;
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
 		};
@@ -568,7 +569,7 @@
 				PRODUCT_NAME = SwiftIpfsApiTests;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};

--- a/SwiftIpfsApi.xcodeproj/xcshareddata/xcschemes/SwiftIpfsApi.xcscheme
+++ b/SwiftIpfsApi.xcodeproj/xcshareddata/xcschemes/SwiftIpfsApi.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1130"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,6 +27,15 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB0A3AAC1BD6705B0090C97A"
+            BuildableName = "SwiftIpfsApi.framework"
+            BlueprintName = "SwiftIpfsApi"
+            ReferencedContainer = "container:SwiftIpfsApi.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -47,17 +56,6 @@
             </SkippedTests>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "AB0A3AAC1BD6705B0090C97A"
-            BuildableName = "SwiftIpfsApi.framework"
-            BlueprintName = "SwiftIpfsApi"
-            ReferencedContainer = "container:SwiftIpfsApi.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -85,8 +83,6 @@
             isEnabled = "NO">
          </EnvironmentVariable>
       </EnvironmentVariables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/SwiftIpfsApi/IpfsApi.swift
+++ b/SwiftIpfsApi/IpfsApi.swift
@@ -189,7 +189,7 @@ public class IpfsApi : IpfsApiClient {
     public convenience init(addr: Multiaddr) throws {
         /// Get the host and port number from the Multiaddr
         let addressString = try addr.string()
-        var protoComponents = addressString.split{$0 == "/"}.map(String.init)
+        let protoComponents = addressString.split{$0 == "/"}.map(String.init)
         if  protoComponents[0].hasPrefix("ip") == true &&
             protoComponents[2].hasPrefix("tcp") == true {
                 

--- a/SwiftIpfsApi/IpfsApi.swift
+++ b/SwiftIpfsApi/IpfsApi.swift
@@ -80,9 +80,9 @@ extension IpfsApiClient {
                 return
             }
 
-            print("The data:",NSString(data: data, encoding: String.Encoding.utf8.rawValue))
+            print("The data:", String(data: data, encoding: .utf8) ?? "n/a")
             let fixedData: Data = fixStreamJson(data)
-            print("The fixed data:",NSString(data: fixedData, encoding: String.Encoding.utf8.rawValue))
+            print("The fixed data:", String(data: fixedData, encoding: .utf8) ?? "n/a")
 			
 			var json: Any
 			do {

--- a/SwiftIpfsApi/IpfsApi.swift
+++ b/SwiftIpfsApi/IpfsApi.swift
@@ -12,8 +12,8 @@ import SwiftMultihash
 
 /// This is to allow a Multihash to be used as a Dictionary key.
 extension Multihash : Hashable {
-    public var hashValue: Int {
-        return String(describing: value).hash
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(value)
     }
 }
 

--- a/SwiftIpfsApi/JsonType.swift
+++ b/SwiftIpfsApi/JsonType.swift
@@ -9,10 +9,10 @@
 import Foundation
 
 public enum JsonType {
-    case Object([Swift.String : JsonType])
-    case Array([JsonType])
-    case String(Swift.String)
-    case Number(NSNumber)
+    case object([String: JsonType])
+    case array([JsonType])
+    case string(String)
+    case number(NSNumber)
     case null
 }
 
@@ -21,13 +21,13 @@ public extension JsonType {
     
     static func parse(_ json: AnyObject) -> JsonType {
         switch json {
-        case let value as [AnyObject]: return .Array(value.map(parse))
+        case let value as [AnyObject]: return .array(value.map(parse))
             
-        case let value as [Swift.String : AnyObject]: return .Object(value.map(parse))
+        case let value as [String: AnyObject]: return .object(value.map(parse))
             
-        case let value as Swift.String: return .String(value)
+        case let value as String: return .string(value)
             
-        case let value as NSNumber: return .Number(value)
+        case let value as NSNumber: return .number(value)
             
         case let value as JsonType: return value
             
@@ -38,31 +38,30 @@ public extension JsonType {
 
 /// Use introspection to make the extraction of the value easier.
 public extension JsonType {
-    
-    var string: Swift.String? {
+    var string: String? {
         switch self {
-        case .String(let string): return string
+        case .string(let string): return string
         default: return nil
         }
     }
     
     var number: NSNumber? {
         switch self {
-        case .Number(let number): return number
+        case .number(let number): return number
         default: return nil
         }
     }
     
-    var object: [Swift.String : JsonType]? {
+    var object: [String: JsonType]? {
         switch self {
-        case .Object(let object): return object
+        case .object(let object): return object
         default: return nil
         }
     }
     
     var array: [JsonType]? {
         switch self {
-        case .Array(let array): return array
+        case .array(let array): return array
         default: return nil
         }
     }

--- a/SwiftIpfsApi/MerkleNode.swift
+++ b/SwiftIpfsApi/MerkleNode.swift
@@ -21,14 +21,9 @@ struct MerkleData {
     var type: Int?
     var links: [MerkleNode]?
     var data: [UInt8]?
-    
-//    init(hash: String? = nil, name: String? = nil, size: Int? = nil, type: Int? = nil, links: [MerkleNode]? = nil, data: [UInt8]? = nil) {
-//        self.name = name
-//    }
 }
 
-/// TODO: Change this to a struct?
-public class MerkleNode {
+public struct MerkleNode: Equatable {
     public let hash: Multihash?
     public let name: String?
     public let size: Int?
@@ -36,19 +31,19 @@ public class MerkleNode {
     public let links: [MerkleNode]?
     public let data: [UInt8]?
     
-    public convenience init(hash: String) throws {
+    public init(hash: String) throws {
         try self.init(hash: hash, name: nil)
     }
     
-    public convenience init(hash: String, name: String?) throws {
+    public init(hash: String, name: String?) throws {
         try self.init(hash: hash, name: name, size: nil, type: nil, links: nil, data: nil)
     }
     
-    convenience init(data: MerkleData) throws {
-        guard data.hash != nil else {
+    init(data: MerkleData) throws {
+        guard let safeHash = data.hash else {
             throw MerkleNodeError.requiredValueMissing("No hash provided!")
         }
-        try self.init(hash: data.hash!, name: data.name, size: data.size, type: data.type, links: data.links, data: data.data)
+        try self.init(hash: safeHash, name: data.name, size: data.size, type: data.type, links: data.links, data: data.data)
     }
     
     public init(hash: String, name: String?, size: Int?, type: Int?, links: [MerkleNode]?, data: [UInt8]?) throws {
@@ -67,6 +62,8 @@ public class MerkleNode {
         }
     }
 }
+
+
 public func merkleNodesFromJson(_ rawJson: JsonType) throws -> [MerkleNode?] {
     var nodes = [MerkleNode?]()
     
@@ -244,8 +241,4 @@ public func merkleNodeFromJson(_ rawJson: AnyObject) throws -> MerkleNode {
     }
 
     return try MerkleNode(hash: hash, name: name, size: size, type: type, links: links, data: data)
-}
-
-public func == (lhs: MerkleNode, rhs: MerkleNode) -> Bool {
-    return lhs.hash == rhs.hash
 }

--- a/SwiftIpfsApi/NetworkIo.swift
+++ b/SwiftIpfsApi/NetworkIo.swift
@@ -12,12 +12,12 @@ import Foundation
 
 public protocol NetworkIo {
     
-    func receiveFrom(_ source: String, completionHandler: @escaping (Data) throws -> Void) throws
+    func receiveFrom(_ source: String, completionHandler: @escaping (Result<Data, Error>) -> Void)
 
     func streamFrom(_ source: String, updateHandler: @escaping (Data, URLSessionDataTask) throws -> Bool, completionHandler: @escaping (AnyObject) throws -> Void) throws
     
-    func sendTo(_ target: String, content: Data, completionHandler: @escaping (Data) -> Void) throws
+    func sendTo(_ target: String, content: Data, completionHandler: @escaping (Result<Data, Error>) -> Void)
 
     /// If we want to send location addressed content
-    func sendTo(_ target: String, filePath: String, completionHandler: @escaping (Data) -> Void) throws
+    func sendTo(_ target: String, filePath: String, completionHandler: @escaping (Result<Data, Error>) -> Void)
 }

--- a/SwiftIpfsApi/Subcommands/Dht.swift
+++ b/SwiftIpfsApi/Subcommands/Dht.swift
@@ -16,11 +16,8 @@ public class Dht : ClientSubCommand {
     var parent: IpfsApiClient?
     
     /** FindProviders will return a list of peers who are able to provide the value requested. */
-//    public func findProvs(_ hash: Multihash, numProviders: Int = 20, completionHandler: @escaping (JsonType) -> Void) throws {
-//        try parent!.fetchJson("dht/findprovs?arg=\(b58String(hash))&num-providers=\(numProviders)", completionHandler: completionHandler)
-//    }
     public func findProvs(_ hash: Multihash, numProviders: Int = 20, completionHandler: @escaping (JsonType) -> Void) throws {
-        /// Two test closures to be passed to the fetchStreamJson as parameters.
+        // Two test closures to be passed to the fetchStreamJson as parameters.
         let comp = { (result: AnyObject) -> Void in
             print("Job done")
         }
@@ -47,27 +44,15 @@ public class Dht : ClientSubCommand {
             var providers = [JsonType]()
             // A valid response can either be an array of objects or an object.
             switch parsedJ {
-            case JsonType.Array(let array):
-//                print("we iz got de arrays")
+            case JsonType.array(let array):
                 providers += array.filter { $0.object?["Type"]?.number == 4 }
-//                for obj in array {
-//                    if let jobj = obj.object, jobj["Type"]?.number == 4 {
-//                            providers += jobj
-//                    }
-//                }
-            case JsonType.Object(let obj):
-//                print("we iz got de hobj innit? \(obj)")
+            case JsonType.object(let obj):
                 if obj["Type"]?.number == 4 {
                     providers.append(parsedJ)
                 }
-//                if let provs = getHash(from: obj, forResponse: 4) {
-//                    providers += provs
-//                }
-                
             default:
-                print("fukkal")
+                break
             }
-            
             
             if providers.count >= numProviders {
                 print("We found these providers \(providers)")
@@ -76,26 +61,6 @@ public class Dht : ClientSubCommand {
                 
             }
 
-//            guard let jarray = parsedJ.array else {
-//                print("No array in parsed json update \(parsedJ)")
-//                return true
-//            }
-//
-//            for obj in jarray {
-//                print("json: \(String(describing: obj.object?["Type"]))")
-//            }
-            
-//            print("json: \(json)")
-//
-//            if let arr = json as? [AnyObject] {
-//                for res in arr {
-//                    print(res)
-//                }
-//            } else {
-//                if let dict = json as? [String: AnyObject] {
-//                    print("It's a dict!:",dict )
-//                }
-//            }
             return true
         }
         
@@ -103,22 +68,22 @@ public class Dht : ClientSubCommand {
     }
    
     /** Run a 'findClosestPeers' query through the DHT */
-    public func query(_ hash: Multihash, completionHandler: @escaping (JsonType) -> Void) throws {
-        try parent!.fetchJson("dht/query?arg=" + b58String(hash) , completionHandler: completionHandler)
+    public func query(_ hash: Multihash, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("dht/query?arg=" + b58String(hash) , completionHandler: completionHandler)
     }
     
     /** Run a 'FindPeer' query through the DHT */
-    public func findpeer(_ hash: Multihash, completionHandler: @escaping (JsonType) -> Void) throws {
-        try parent!.fetchJson("dht/findpeer?arg=" + b58String(hash), completionHandler: completionHandler)
+    public func findpeer(_ hash: Multihash, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("dht/findpeer?arg=" + b58String(hash), completionHandler: completionHandler)
     }
     
     /** Will return the value stored in the dht at the given key */
-    public func get(_ hash: Multihash, completionHandler: @escaping (JsonType) -> Void) throws {
-        try parent!.fetchJson("dht/get?arg=" + b58String(hash), completionHandler: completionHandler)
+    public func get(_ hash: Multihash, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("dht/get?arg=" + b58String(hash), completionHandler: completionHandler)
     }
     
     /** Will store the given key value pair in the dht. */
-    public func put(_ key: String, value: String, completionHandler: @escaping (JsonType) -> Void) throws {
-        try parent!.fetchJson("dht/put?arg=\(key)&arg=\(value)", completionHandler: completionHandler)
+    public func put(_ key: String, value: String, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("dht/put?arg=\(key)&arg=\(value)", completionHandler: completionHandler)
     }
 }

--- a/SwiftIpfsApi/Subcommands/Diag.swift
+++ b/SwiftIpfsApi/Subcommands/Diag.swift
@@ -14,18 +14,22 @@ public class Diag : ClientSubCommand {
     var parent: IpfsApiClient?
     
     /** Generates a network diagnostics report */
-    public func net(_ completionHandler: @escaping (String) -> Void) throws {
-        try parent!.fetchBytes("diag/net?stream-channels=true") {
-            bytes in
-            completionHandler(String(bytes: bytes, encoding: String.Encoding.utf8)!)
+    public func net(_ completionHandler: @escaping (Result<String, Error>) -> Void) {
+        parent!.fetchBytes("diag/net?stream-channels=true") { result in
+            let transformation = result.flatMap { bytes -> Result<String, Error> in
+                return .success(String(bytes: bytes, encoding: .utf8)!)
+            }
+            completionHandler(transformation)
         }
     }
     
     /* Prints out system diagnostic information. */
-    public func sys(_ completionHandler: @escaping (String) -> Void) throws {
-        try parent!.fetchBytes("diag/sys?stream-channels=true") {
-            bytes in
-            completionHandler(String(bytes: bytes, encoding: String.Encoding.utf8)!)
+    public func sys(_ completionHandler: @escaping (Result<String, Error>) -> Void) {
+        parent!.fetchBytes("diag/sys?stream-channels=true") { result in
+            let transformation = result.flatMap { bytes -> Result<String, Error> in
+                return .success(String(bytes: bytes, encoding: .utf8)!)
+            }
+            completionHandler(transformation)
         }
     }
 }

--- a/SwiftIpfsApi/Subcommands/File.swift
+++ b/SwiftIpfsApi/Subcommands/File.swift
@@ -20,7 +20,7 @@ public class File : ClientSubCommand {
     The JSON output contains size information.  For files, the child size is the
     total size of the file contents.  
     For directories, the child size is the IPFS link size. */
-    public func ls(_ path: String, completionHandler: @escaping (JsonType) -> Void) throws {
-        try parent!.fetchJson("file/ls?arg=" + path, completionHandler: completionHandler)
+    public func ls(_ path: String, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("file/ls?arg=" + path, completionHandler: completionHandler)
     }
 }

--- a/SwiftIpfsApi/Subcommands/IpfsObject.swift
+++ b/SwiftIpfsApi/Subcommands/IpfsObject.swift
@@ -15,14 +15,14 @@ public class IpfsObject : ClientSubCommand {
     var parent: IpfsApiClient?
     
     public enum ObjectTemplates: String {
-        case UnixFsDir = "unixfs-dir"
+        case unixFsDir = "unixfs-dir"
     }
     
     public enum ObjectPatchCommand: String {
-        case AddLink    = "add-link"
-        case RmLink     = "rm-link"
-        case SetData    = "set-data"
-        case AppendData = "append-data"
+        case addLink = "add-link"
+        case rmLink = "rm-link"
+        case setData = "set-data"
+        case appendData = "append-data"
     }
     
     /**
@@ -34,102 +34,96 @@ public class IpfsObject : ClientSubCommand {
      Available templates:
     	* unixfs-dir
      */
-    public func new(_ template: ObjectTemplates? = nil, completionHandler: @escaping (MerkleNode) throws -> Void) throws {
+    public func new(_ template: ObjectTemplates? = nil, completionHandler: @escaping (Result<MerkleNode, Error>) -> Void) {
         var request = "object/new?stream-channels=true"
-        if template != nil { request += "&arg=\(template!.rawValue)" }
-        try parent!.fetchJson(request) {
-            result in
-            try completionHandler( try merkleNodeFromJson2(result) )
+
+        if let safeTemplate = template {
+            request += "&arg=\(safeTemplate.rawValue)"
+        }
+
+         parent!.fetchJson(request) { result in
+            let transformation = result.flatMap { json -> Result<MerkleNode, Error> in
+                return .init(catching: { try merkleNodeFromJson2(json) } )
+            }
+            completionHandler(transformation)
         }
     }
     
     /** IpfsObject put is a plumbing command for storing DAG nodes.
      Its input is a byte array, and the output is a base58 encoded multihash.
      */
-    public func put(_ data: [UInt8], completionHandler: @escaping (MerkleNode) -> Void) throws {
-        let data2 = Data(bytes: UnsafePointer<UInt8>(data), count: data.count)
+    public func put(_ data: [UInt8], completionHandler: @escaping (Result<MerkleNode, Error>) -> Void) {
+        let data = Data(bytes: UnsafePointer<UInt8>(data), count: data.count)
         
-        try parent!.net.sendTo(parent!.baseUrl+"object/put?stream-channels=true", content: data2) {
-            result in
-            
-            do {
-                print(result)
-                guard let json = try JSONSerialization.jsonObject(with: result, options: JSONSerialization.ReadingOptions.allowFragments) as? [String : AnyObject] else {
-                    throw IpfsApiError.jsonSerializationFailed
+        parent!.net.sendTo(parent!.baseUrl+"object/put?stream-channels=true", content: data) { result in
+            let transformation: Result<MerkleNode, Error> = .init {
+                guard let json = try JSONSerialization.jsonObject(with: data,
+                                                                  options: .allowFragments) as? [String : AnyObject] else {
+                                                                    throw IpfsApiError.jsonSerializationFailed
                 }
-                
-                completionHandler(try merkleNodeFromJson(json as AnyObject))
-            } catch {
-                print("IpfsObject Error:\(error)")
+
+                return try merkleNodeFromJson(json as AnyObject)
             }
+            completionHandler(transformation)
         }
     }
     
     /** IpfsObject get is a plumbing command for retreiving DAG nodes.
      Its input is a base58 encoded Multihash and it returns a MerkleNode.
      */
-    public func get(_ hash: Multihash, completionHandler: @escaping (MerkleNode) -> Void) throws {
-        
-        try parent!.fetchJson("object/get?stream-channels=true&arg=" + b58String(hash)){
-            result in
-            
-            guard var res = result.object else { throw IpfsApiError.resultMissingData("No object found!")}
-            res["Hash"] = .String(b58String(hash))
-            completionHandler(try merkleNodeFromJson2(.Object(res)))
+    public func get(_ hash: Multihash, completionHandler: @escaping (Result<MerkleNode, Error>) -> Void) {
+        parent!.fetchJson("object/get?stream-channels=true&arg=" + b58String(hash)) { result in
+            let transformation = result.flatMap { json -> Result<MerkleNode, Error> in
+                do {
+                    guard var res = json.object else {
+                        return .failure(IpfsApiError.resultMissingData("No object found!"))
+                    }
+
+                    res["Hash"] = .string(b58String(hash))
+                    return .success(try merkleNodeFromJson2(.object(res)))
+                } catch {
+                    return .failure(error)
+                }
+            }
+            completionHandler(transformation)
         }
     }
     
-    public func links(_ hash: Multihash, completionHandler: @escaping (MerkleNode) throws -> Void) throws {
-        
-        try parent!.fetchJson("object/links?stream-channels=true&arg=" + b58String(hash)){
-            result in
-            try completionHandler(try merkleNodeFromJson2(result))
+    public func links(_ hash: Multihash, completionHandler: @escaping (Result<MerkleNode, Error>) -> Void) {
+        parent!.fetchJson("object/links?stream-channels=true&arg=" + b58String(hash)) { result in
+            completionHandler(.init(catching: {
+                try merkleNodeFromJson2(try result.get())
+            }))
         }
     }
     
-    public func stat(_ hash: Multihash, completionHandler: @escaping (JsonType) -> Void) throws {
-        
-        try parent!.fetchJson("object/stat?stream-channels=true&arg=" + b58String(hash), completionHandler: completionHandler)
+    public func stat(_ hash: Multihash, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("object/stat?stream-channels=true&arg=" + b58String(hash), completionHandler: completionHandler)
     }
     
-    public func data(_ hash: Multihash, completionHandler: @escaping ([UInt8]) -> Void) throws {
-        
-        try parent!.fetchBytes("object/data?stream-channels=true&arg=" + b58String(hash), completionHandler: completionHandler)
+    public func data(_ hash: Multihash, completionHandler: @escaping (Result<[UInt8], Error>) -> Void) {
+        parent!.fetchBytes("object/data?stream-channels=true&arg=" + b58String(hash), completionHandler: completionHandler)
     }
-    
-//    public func patch(_ root: Multihash, cmd: ObjectPatchCommand, args: String..., completionHandler: @escaping (MerkleNode) throws -> Void) throws {
-//
-//        var request: String = "object/patch?arg=\(b58String(root))&arg=\(cmd.rawValue)&"
-//
-//        if cmd == .AddLink && args.count != 2 {
-//            throw IpfsApiError.ipfsObjectError("Wrong number of arguments to \(cmd.rawValue)")
-//        }
-//
-//        request += buildArgString(args)
-//
-//        try parent!.fetchJson(request) {
-//            result in
-//            try completionHandler(try merkleNodeFromJson2(result))
-//        }
-//    }
+
     // change root to String ?
-    public func patch(_ root: Multihash, cmd: ObjectPatchCommand, args: String..., completionHandler: @escaping (MerkleNode) throws -> Void) throws {
-        
-        var request: String = "object/patch"
+    public func patch(_ root: Multihash, cmd: ObjectPatchCommand, args: String..., completionHandler: @escaping (Result<MerkleNode, Error>) -> Void) {
+        var request = "object/patch"
+
         switch cmd {
-        case .AddLink:
+        case .addLink:
             print("patch add link")
+
             guard args.count == 2 else {
-                throw IpfsApiError.ipfsObjectError("Wrong number of arguments to \(cmd.rawValue)")
+                return completionHandler(.failure(IpfsApiError.ipfsObjectError("Wrong number of arguments to \(cmd.rawValue)")))
             }
             request += "/add-link"
-        case .RmLink:
+        case .rmLink:
             print("patch remove link")
             request += "/rm-link"
-        case .SetData:
+        case .setData:
             print("patch set data")
             request += "/set-data"
-        case .AppendData:
+        case .appendData:
             print("patch append data")
             request += "/append-data"
         }
@@ -138,9 +132,10 @@ public class IpfsObject : ClientSubCommand {
         
         request += buildArgString(args)
         
-        try parent!.fetchJson(request) {
-            result in
-            try completionHandler(try merkleNodeFromJson2(result))
+        parent!.fetchJson(request) { result in
+            completionHandler(.init {
+                try merkleNodeFromJson2(try result.get())
+            })
         }
     }
 }

--- a/SwiftIpfsApi/Subcommands/Pin.swift
+++ b/SwiftIpfsApi/Subcommands/Pin.swift
@@ -14,69 +14,93 @@ public class Pin : ClientSubCommand {
     
     var parent: IpfsApiClient?
     
-    public func add(_ hash: Multihash, completionHandler: @escaping ([Multihash]) -> Void) throws {
-        
-        try parent!.fetchJson("pin/add?stream-channels=true&arg=\(b58String(hash))") {
-            result in
-            
-            guard let objects = result.object?["Pins"]?.array else {
-                throw IpfsApiError.pinError("Pin.add error: No Pinned objects in JSON data.")
+    public func add(_ hash: Multihash, completionHandler: @escaping (Result<[Multihash], Error>) -> Void) {
+        parent!.fetchJson("pin/add?stream-channels=true&arg=\(b58String(hash))") { result in
+            let transformation = result.flatMap { json -> Result<[Multihash], Error> in
+                do {
+                    guard let objects = json.object?["Pins"]?.array else {
+                        throw IpfsApiError.pinError("Pin.add error: No Pinned objects in JSON data.")
+                    }
+
+                    let compactObjects: [Multihash] = try objects.compactMap {
+                        guard let safeString = $0.string else {
+                            return nil
+                        }
+
+                        return try fromB58String(safeString)
+                    }
+
+                    return .success(compactObjects)
+                } catch {
+                    return .failure(error)
+                }
             }
-            
-            let multihashes = try objects.map { try fromB58String($0.string!) }
-            
-            completionHandler(multihashes)
+            completionHandler(transformation)
         }
     }
     
     /** List objects pinned to local storage */
-    public func ls(_ completionHandler: @escaping ([Multihash : JsonType]) -> Void) throws {
+    public func ls(_ completionHandler: @escaping (Result<[Multihash: JsonType], Error>) -> Void) {
         
-        /// The default is .Recursive
-        try self.ls(.Recursive) {
-            result in
-            
-            ///turn the result into a [Multihash : AnyObject]
-            var multihashes: [Multihash : JsonType] = [:]
-            if let hashes = result.object {
-                for (k,v) in hashes {
-                    multihashes[try fromB58String(k)] = v
+        // The default is .Recursive
+        ls(.recursive) { result in
+            let transformation = result.flatMap { json -> Result<[Multihash: JsonType], Error> in
+                do {
+                    var multihashes = [Multihash : JsonType]()
+                    if let hashes = json.object {
+                        for (k,v) in hashes {
+                            multihashes[try fromB58String(k)] = v
+                        }
+                    }
+                    return .success(multihashes)
+                } catch {
+                    return .failure(error)
                 }
             }
-            
-            completionHandler(multihashes)
+            completionHandler(transformation)
         }
     }
     
-    public func ls(_ pinType: PinType, completionHandler: @escaping (JsonType) throws -> Void) throws {
-        
-        try parent!.fetchJson("pin/ls?stream-channels=true&t=" + pinType.rawValue) {
-            result in
-            
-            guard let objects = result.object?[IpfsCmdString.Keys.rawValue] else {
-                throw IpfsApiError.pinError("Pin.ls error: No Keys Dictionary in JSON data.")
+    public func ls(_ pinType: PinType, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("pin/ls?stream-channels=true&t=" + pinType.rawValue) { result in
+            let transformation = result.flatMap { data -> Result<JsonType, Error> in
+                guard let objects = data.object?[IpfsCmdString.Keys.rawValue] else {
+                    return .failure(IpfsApiError.pinError("Pin.ls error: No Keys Dictionary in JSON data."))
+                }
+
+                return .success(objects)
             }
-            
-            try completionHandler(objects)
+            completionHandler(transformation)
         }
     }
     
-    public func rm(_ hash: Multihash, completionHandler: @escaping ([Multihash]) -> Void) throws {
-        try self.rm(hash, recursive: true, completionHandler: completionHandler)
+    public func rm(_ hash: Multihash, completionHandler: @escaping (Result<[Multihash], Error>) -> Void) {
+        self.rm(hash, recursive: true, completionHandler: completionHandler)
     }
     
-    public func rm(_ hash: Multihash, recursive: Bool, completionHandler: @escaping ([Multihash]) -> Void) throws {
-        
-        try parent!.fetchJson("pin/rm?stream-channels=true&r=\(recursive)&arg=\(b58String(hash))") {
-            result in
-            
-            guard let objects = result.object?["Pins"]?.array else {
-                throw IpfsApiError.pinError("Pin.rm error: No Pinned objects in JSON data.")
+    public func rm(_ hash: Multihash, recursive: Bool, completionHandler: @escaping (Result<[Multihash], Error>) -> Void) {
+        parent!.fetchJson("pin/rm?stream-channels=true&r=\(recursive)&arg=\(b58String(hash))") { result in
+
+            let transformation = result.flatMap { data -> Result<[Multihash], Error> in
+                do {
+                    guard let objects = data.object?["Pins"]?.array else {
+                        throw IpfsApiError.pinError("Pin.rm error: No Pinned objects in JSON data.")
+                    }
+
+                    let compactObjects: [Multihash] = try objects.compactMap {
+                        guard let safeString = $0.string else {
+                            return nil
+                        }
+
+                        return try fromB58String(safeString)
+                    }
+
+                    return .success(compactObjects)
+                } catch {
+                    return .failure(error)
+                }
             }
-            
-            let multihashes = try objects.map { try fromB58String($0.string!) }
-            
-            completionHandler(multihashes)
+            completionHandler(transformation)
         }
     }
     

--- a/SwiftIpfsApi/Subcommands/Refs.swift
+++ b/SwiftIpfsApi/Subcommands/Refs.swift
@@ -14,49 +14,33 @@ public class Refs : ClientSubCommand {
     
     var parent: IpfsApiClient?
     
-//    public func local(_ completionHandler: @escaping ([Multihash]) -> Void) throws {
-//        try parent!.fetchData("refs/local") {
-//            (data: Data) in
-//
-//            /// First we turn the data into a string
-//            guard let dataString = String(data: data, encoding: String.Encoding.utf8) else {
-//                throw IpfsApiError.refsError("Could not convert data into string.")
-//            }
-//
-//            /** The resulting string is a bunch of newline separated strings so:
-//             1) Split the string up by the separator into a subsequence,
-//             2) Map each resulting subsequence into a string,
-//             3) Map each string into a Multihash with fromB58String. */
-//            let multiAddrs = try dataString.split(separator: "\n").map(String.init).map{ try fromB58String($0) }
-//            completionHandler(multiAddrs)
-//        }
-//    }
-    
     struct Reference : Codable {
         let Ref: String
         let Err: String
     }
     
-    public func local(_ completionHandler: @escaping ([Multihash]) -> Void) throws {
-        try parent!.fetchData("refs/local") {
-            (data: Data) in
-            let fixedJsonData = fixStreamJson(data)
-            let decoder = JSONDecoder()
-            let refs = try decoder.decode([Reference].self, from: fixedJsonData)
-            /** The resulting string is a bunch of newline separated strings so:
-             1) Split the string up by the separator into a subsequence,
-             2) Map each resulting subsequence into a string,
-             3) Map each string into a Multihash with fromB58String. */
-            //            let multiAddrs = try dataString.split(separator: "\n").map(String.init).map{ try fromB58String($0) }
-            let c = try refs.map{ reference -> Multihash in
-                //try fromB58String($0.Ref)
-                print("reference is \(reference.Ref)")
-                print("error is \(reference.Err)")
-                return try fromB58String(reference.Ref)
+    public func local(_ completionHandler: @escaping (Result<[Multihash], Error>) -> Void) {
+        parent!.fetchData("refs/local") { result in
+            let transformation = result.flatMap { data -> Result<[Multihash], Error> in
+                do {
+                    let fixedJsonData = fixStreamJson(data)
+                    let decoder = JSONDecoder()
+                    let refs = try decoder.decode([Reference].self, from: fixedJsonData)
+                    /** The resulting string is a bunch of newline separated strings so:
+                     1) Split the string up by the separator into a subsequence,
+                     2) Map each resulting subsequence into a string,
+                     3) Map each string into a Multihash with fromB58String. */
+                    let c = try refs.map { reference -> Multihash in
+                        print("reference is \(reference.Ref)")
+                        print("error is \(reference.Err)")
+                        return try fromB58String(reference.Ref)
+                    }
+                    return .success(c)
+                } catch {
+                    return .failure(error)
+                }
             }
-            let multiAddrs = c
-            completionHandler(multiAddrs)
+            completionHandler(transformation)
         }
     }
-
 }

--- a/SwiftIpfsApi/Subcommands/Repo.swift
+++ b/SwiftIpfsApi/Subcommands/Repo.swift
@@ -13,20 +13,7 @@ public class Repo : ClientSubCommand {
     
     /** gc is a plumbing command that will sweep the local set of stored objects
      and remove ones that are not pinned in order to reclaim hard disk space. */
-    public func gc(_ completionHandler: @escaping (JsonType) -> Void) throws {
-        try parent!.fetchJson("repo/gc", completionHandler: completionHandler)
+    public func gc(_ completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("repo/gc", completionHandler: completionHandler)
     }
-//    public func gc(completionHandler: ([[String : AnyObject]]) -> Void) throws {
-//        try parent!.fetchData("repo/gc") {
-//            (rawJson: NSData) in
-//            
-//            /// Check for streamed JSON format and wrap & separate.
-//            let data = fixStreamJson(rawJson)
-//            
-//            guard let json = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.AllowFragments) as? [[String : AnyObject]] else { throw IpfsApiError.JsonSerializationFailed
-//            }
-//            
-//            completionHandler(json)
-//        }
-//    }
 }

--- a/SwiftIpfsApi/Subcommands/Stats.swift
+++ b/SwiftIpfsApi/Subcommands/Stats.swift
@@ -16,7 +16,7 @@ public class Stats : ClientSubCommand {
         proto: String? = nil,
         poll: Bool = false,
         interval: String? = nil,
-        completionHandler: @escaping (JsonType) -> Void) throws {
-            try parent!.fetchJson("stats/bw", completionHandler: completionHandler)
+        completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+            parent!.fetchJson("stats/bw", completionHandler: completionHandler)
     }
 }

--- a/SwiftIpfsApi/Subcommands/Swarm.swift
+++ b/SwiftIpfsApi/Subcommands/Swarm.swift
@@ -16,43 +16,52 @@ public class Swarm : ClientSubCommand {
     /** Lists the set of peers this node is connected to.
         The completionHandler is passed an array of Multiaddr that represent the peers.
      */
-    public func peers(_ completionHandler: @escaping ([Multiaddr]) throws -> Void) throws {
-        try parent!.fetchJson("swarm/peers?stream-channels=true") {
-            result in
-            
-            var addresses: [Multiaddr] = []
-            if let swarmPeers = result.object?[IpfsCmdString.Peers.rawValue]?.array {
-                /// Make an array of Multiaddr from each peer in swarmPeers.
-                addresses = try swarmPeers.map {
-                    guard let peer = $0.object?["Addr"]?.string else {  throw IpfsApiError.nilData }
-                    // Broken until multiaddr can deal with p2p-circuit multiaddr
-                    return try newMultiaddr(peer)
+    public func peers(_ completionHandler: @escaping (Result<[Multiaddr], Error>) -> Void) {
+        parent!.fetchJson("swarm/peers?stream-channels=true") { result in
+            let transformation = result.flatMap { json -> Result<[Multiaddr], Error> in
+                guard let swarmPeers = json.object?[IpfsCmdString.Peers.rawValue]?.array else {
+                    return .success([])
+                }
+
+                do {
+                    // Make an array of Multiaddr from each peer in swarmPeers.
+                    let addresses: [Multiaddr] = try swarmPeers.map {
+                        guard let peer = $0.object?["Addr"]?.string else { throw IpfsApiError.nilData }
+
+                        // Broken until multiaddr can deal with p2p-circuit multiaddr
+                        return try newMultiaddr(peer)
+                    }
+                    return .success(addresses)
+                } catch {
+                    return .failure(error)
                 }
             }
-            
-            /// convert the data into a Multiaddr array and pass it to the handler
-            try completionHandler(addresses)
+            completionHandler(transformation)
         }
     }
     
     /** lists all addresses this node is aware of. */
-    public func addrs(_ completionHandler: @escaping (JsonType) throws -> Void) throws {
-        
-        try parent!.fetchJson("swarm/addrs?stream-channels=true") {
-            result in
-            guard let addrsData = result.object?[IpfsCmdString.Addrs.rawValue] else {
-                throw IpfsApiError.swarmError("Swarm.addrs error: No Addrs key in JSON data.")
+    public func addrs(_ completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("swarm/addrs?stream-channels=true") { result in
+            switch result {
+            case .success(let json):
+                guard let addrsData = json.object?[IpfsCmdString.Addrs.rawValue] else {
+                    return completionHandler(.failure(IpfsApiError.swarmError("Swarm.addrs error: No Addrs key in JSON data.")))
+                }
+
+                completionHandler(.success(addrsData))
+            case .failure(let error):
+                completionHandler(.failure(error))
             }
-            try completionHandler(addrsData)
         }
     }
     
     /** opens a new direct connection to a peer address. */
-    public func connect(_ multiaddr: String, completionHandler: @escaping (JsonType) throws -> Void) throws {
-        try parent!.fetchJson("swarm/connect?arg=" + multiaddr, completionHandler: completionHandler)
+    public func connect(_ multiaddr: String, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("swarm/connect?arg=" + multiaddr, completionHandler: completionHandler)
     }
     
-    public func disconnect(_ multiaddr: String, completionHandler: @escaping (JsonType) throws -> Void) throws {
-        try parent!.fetchJson("swarm/disconnect?arg=" + multiaddr, completionHandler: completionHandler)
+    public func disconnect(_ multiaddr: String, completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("swarm/disconnect?arg=" + multiaddr, completionHandler: completionHandler)
     }
 }

--- a/SwiftIpfsApi/Subcommands/Update.swift
+++ b/SwiftIpfsApi/Subcommands/Update.swift
@@ -11,13 +11,11 @@ public class Update : ClientSubCommand {
     
     var parent: IpfsApiClient?
     
-    public func check(_ completionHandler: @escaping (JsonType) -> Void) throws {
-        
-        try parent!.fetchJson("update/check", completionHandler: completionHandler )
+    public func check(_ completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("update/check", completionHandler: completionHandler )
     }
     
-    public func log(_ completionHandler: @escaping (JsonType) -> Void) throws {
-        
-        try parent!.fetchJson("update/log", completionHandler: completionHandler )
+    public func log(_ completionHandler: @escaping (Result<JsonType, Error>) -> Void) {
+        parent!.fetchJson("update/log", completionHandler: completionHandler )
     }
 }

--- a/SwiftIpfsApiTests/SwiftIpfsApiTests.swift
+++ b/SwiftIpfsApiTests/SwiftIpfsApiTests.swift
@@ -14,408 +14,350 @@ import SwiftMultihash
 
 class SwiftIpfsApiTests: XCTestCase {
 
-//    var hostString      = "ipfs-thing.localhost"//192.168.5.9" //127.0.0.1" //"192.168.5.8"
     var hostString      = "127.0.0.1"
     let hostPort        = 5001
     
     /// Your own IPNS node hash
     let nodeIdString    = "QmWNwhBWa9sWPvbuS5XNaLp6Phh5vRN77BZRF5xPWG3FN1"
-//    let nodeIdString    = "QmRzsihDMWML1dNPa51qwD2dacvZPfTrqsQt4pi1DWGJFP"
     
     /// Another known neighbouring hash
-//    let altNodeIdString = "QmWqjusr86LThkYgjAbNMa8gJ55wzVufkcv5E2TFfzYZXu"
     let altNodeIdString = "QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z"
 
     let peerIPAddr = "/ip4/10.12.0.8/tcp/4001"
     
     let currentIpfsVersion = "0.4.14"
     
-    override func setUp() {
-        super.setUp()
-        
-    }
-    
-    override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
-        super.tearDown()
-    }
-    
-    func testBoundary() {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        let soRandom = Multipart.createBoundary()
-        print(soRandom.count)
+    // FIX: Fails due to issue in Multihash not recognizing new non Qm style hashes.
+    func testRefsLocal() throws {
+        let completionExpectation = expectation(description: "testRefsLocal")
+
+        let api = try IpfsApi(host: self.hostString, port: self.hostPort)
+
+        api.refs.local { result in
+            XCTAssertNotNil(result.getOrNil())
+            completionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 100.0)
     }
     
     // FIX: Fails due to issue in Multihash not recognizing new non Qm style hashes.
-    func testRefsLocal() {
-        
-        let expectation = XCTestExpectation(description: "testRefsLocal")
-        
-        do {
+    func testPin() throws {
+        let pinAddExpectation = expectation(description: "testPinAdd")
+        let pinLsExpectation = expectation(description: "testPinLs")
+        let pinRmExpectation = expectation(description: "testPinRm")
 
-        
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        let multihash = try fromB58String("Qmb4b83vuYMmMYqj5XaucmEuNAcwNBATvPL6CNuQosjr91")
 
-            try api.refs.local() { (localRefs: [Multihash]) in
-                
-                for mh in localRefs {
-                    // Bad assumption that the string is necessarily in base 58.
-                    // Check first.
-                    print("multihash string :\(mh.string())")
-//                    print(b58String(mh))
+        api.pin.add(multihash) { pinnedHashes in
+            XCTAssertNotNil(pinnedHashes.getOrNil())
+            pinAddExpectation.fulfill()
+
+            // Pin Ls. Visual inspection for now. Change to check for added pin.
+            api.pin.ls { result in
+                XCTAssertNotNil(result.getOrNil())
+                pinLsExpectation.fulfill()
+
+                // Pin Rm. Remove previously pinned hash.
+                api.pin.rm(multihash) { removed in
+                    pinRmExpectation.fulfill()
                 }
-                
-                expectation.fulfill()
             }
-        } catch {
-            XCTFail("test failed with error \(error)")
         }
-        
-        wait(for: [expectation], timeout: 50.0)
+
+        waitForExpectations(timeout: 50.0)
     }
     
-    // FIX: Fails due to issue in Multihash not recognizing new non Qm style hashes.
-    func testPin() {
-        
-        let pinAddExpectation = XCTestExpectation(description: "testPinAdd")
-        let pinLsExpectation = XCTestExpectation(description: "testPinLs")
-        let pinRmExpectation = XCTestExpectation(description: "testPinRm")
-        
-        do {
-            
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            let multihash = try fromB58String("Qmb4b83vuYMmMYqj5XaucmEuNAcwNBATvPL6CNuQosjr91")
-            
-            try api.pin.add(multihash) {
-                (pinnedHashes: [Multihash]) in
-                
-                for mh in pinnedHashes {
-                    print(b58String(mh))
-                }
-                
-                pinAddExpectation.fulfill()
-                
-                // Pin Ls. Visual inspection for now. Change to check for added pin.
-                try? api.pin.ls() { (pinned: [Multihash : JsonType]) in
-    
-                    for (k,v) in pinned {
-                        print("\(b58String(k)) \((v.object?["Type"]?.string)!)")
-                    }
-                    pinLsExpectation.fulfill()
+    func testRepo() throws {
+        let lsExpectation = expectation(description: "ls")
+        let repoGcExpectation = expectation(description: "testRepoGc")
 
-                    // Pin Rm. Remove previously pinned hash.
-                    try? api.pin.rm(multihash) { (removed: [Multihash]) in
+        let api = try IpfsApi(host: hostString, port: hostPort)
+
+        /** First we do an ls of something we know isn't pinned locally.
+         This causes it to be copied to the local node so that the gc has
+         something to collect. */
+
+        let multihash = try fromB58String("QmTtqKeVpgQ73KbeoaaomvLoYMP7XKemhTgPNjasWjfh9b")
         
-                        for hash in removed {
-                            print("Removed hash:",b58String(hash))
-                        }
-                       
-                        pinRmExpectation.fulfill()
-                    }
-                }
+        api.ls(multihash) { _ in
+            lsExpectation.fulfill()
+
+            api.repo.gc { result in
+                repoGcExpectation.fulfill()
             }
-        } catch {
-            XCTFail("test failed with error \(error)")
         }
-        
-        wait(for: [pinAddExpectation, pinLsExpectation, pinRmExpectation], timeout: 50.0)
+
+        waitForExpectations(timeout: 300)
+    }
+
+    func testBlock() throws {
+        let blockPutExpectation = expectation(description: "testBlockPut")
+        let blockGetExpectation = expectation(description: "testBlockGet")
+        let blockStatExpectation = expectation(description: "testBlockStat")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        let rawData: [UInt8] = Array("hej verden".utf8)
+
+        api.block.put(rawData) { result in
+            guard let node = try? result.get() else {
+                XCTFail()
+                return
+            }
+
+            XCTAssert(b58String(node.hash!) == "QmR4MtZCAUkxzg8ewgNp6hDVgtqnyojDSWVF4AFG9RWsYw")
+            blockPutExpectation.fulfill()
+        }
+
+        // Block Get.
+        var multihash = try fromB58String("QmR4MtZCAUkxzg8ewgNp6hDVgtqnyojDSWVF4AFG9RWsYw")
+
+        api.block.get(multihash) { result in
+            guard let hashes = try? result.get() else {
+                XCTFail()
+                return
+            }
+
+            let res = String(bytes: hashes, encoding: .utf8)
+            XCTAssert(res == "hej verden")
+            blockGetExpectation.fulfill()
+        }
+
+        // Block Stat.
+        multihash = try fromB58String("QmR4MtZCAUkxzg8ewgNp6hDVgtqnyojDSWVF4AFG9RWsYw")
+
+        api.block.stat(multihash) { result in
+            guard let json = try? result.get() else {
+                XCTFail()
+                return
+            }
+
+            let hash = json.object?["Key"]?.string
+            let size = json.object?["Size"]?.number
+
+            if hash == nil || size == nil
+                || hash != "QmR4MtZCAUkxzg8ewgNp6hDVgtqnyojDSWVF4AFG9RWsYw"
+                || size != 10 {
+                XCTFail()
+            }
+            blockStatExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 50.0)
     }
     
-    func testRepo() {
+    func testObject() throws {
+        let objNewExpectation = expectation(description: "testObjectNew")
+        let objPutExpectation = expectation(description: "testObjectPut")
+        let objGetExpectation = expectation(description: "testObjectGet")
+        let objLinksExpectation = expectation(description: "testObjectLinks")
 
-        let lsExpectation = XCTestExpectation(description: "ls")
-        let repoGcExpectation = XCTestExpectation(description: "testRepoGc")
-        
-        do {
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            
-            /** First we do an ls of something we know isn't pinned locally.
-                This causes it to be copied to the local node so that the gc has
-                something to collect. */
-
-            let multihash = try fromB58String("QmTtqKeVpgQ73KbeoaaomvLoYMP7XKemhTgPNjasWjfh9b")
-        
-            try api.ls(multihash) { _ in
-                
-                lsExpectation.fulfill()
-                
-                try? api.repo.gc() { result in
-                    
-                    if let removed = result.array {
-                        for ref in removed {
-                            print("removed: ",(ref.object?["Key"]?.string)!)
-                        }
-                    }
-                    repoGcExpectation.fulfill()
-                }
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        api.object.new() { result in
+            guard let node = try? result.get() else {
+                XCTFail()
+                return
             }
-        } catch {
-            XCTFail()
+
+            /// A new ipfs object always has the same hash so we can assert against it.
+            XCTAssert(b58String(node.hash!) == "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n")
+            objNewExpectation.fulfill()
         }
-        
-        wait(for: [lsExpectation, repoGcExpectation], timeout: 300.0)
-    }
-    
-    func testBlock() {
-        
-        let blockPutExpectation = XCTestExpectation(description: "testBlockPut")
-        let blockGetExpectation = XCTestExpectation(description: "testBlockGet")
-        let blockStatExpectation = XCTestExpectation(description: "testBlockStat")
-        
-        do {
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            let rawData: [UInt8] = Array("hej verden".utf8)
-            
-            try api.block.put(rawData) { (result: MerkleNode) in
-                
-                XCTAssert(b58String(result.hash!) == "QmR4MtZCAUkxzg8ewgNp6hDVgtqnyojDSWVF4AFG9RWsYw")
-//                print("ipfs.block.put test:")
-//                print("Name: ", result.name ?? "No name!")
-//                print("Hash: ", b58String(result.hash!))
 
-                blockPutExpectation.fulfill()
-            }
-            
-            // Block Get.
-            var multihash = try fromB58String("QmR4MtZCAUkxzg8ewgNp6hDVgtqnyojDSWVF4AFG9RWsYw")
-            
-            try api.block.get(multihash) { (result: [UInt8]) in
-                let res = String(bytes: result, encoding: String.Encoding.utf8)
-                XCTAssert(res == "hej verden")
-                
-                blockGetExpectation.fulfill()
+        // Test Object Put
+        let data = [UInt8]("{ \"Data\" : \"Dauz\" }".utf8)
+
+        api.object.put(data) { result in
+            guard let node = try? result.get() else {
+                XCTFail()
+                return
             }
 
-            // Block Stat.
-            multihash = try fromB58String("QmR4MtZCAUkxzg8ewgNp6hDVgtqnyojDSWVF4AFG9RWsYw")
-            
-            try api.block.stat(multihash) { result in
-                
-                let hash = result.object?["Key"]?.string
-                let size = result.object?["Size"]?.number
-                
-                if hash == nil || size == nil
-                    || hash != "QmR4MtZCAUkxzg8ewgNp6hDVgtqnyojDSWVF4AFG9RWsYw"
-                    || size != 10 {
-                    XCTFail()
-                }
-                blockStatExpectation.fulfill()
-            }
-
-        } catch {
-            XCTFail("test failed with error \(error)")
+            XCTAssert(b58String(node.hash!) == "QmUqvXbE4s9oTQNhBXm2hFapLq1pnuuxsMdxP9haTzivN6")
+            objPutExpectation.fulfill()
         }
-        
-        wait(for: [blockPutExpectation, blockGetExpectation, blockStatExpectation], timeout: 50.0)
+
+        // Test Object Get
+        var multihash = try fromB58String("QmUqvXbE4s9oTQNhBXm2hFapLq1pnuuxsMdxP9haTzivN6")
+
+        api.object.get(multihash) { result in
+            guard let node = try? result.get() else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertEqual(node.data!, Array("Dauz".utf8))
+            objGetExpectation.fulfill()
+        }
+
+        // Test Object Links
+        multihash = try fromB58String("QmR3azp3CCGEFGZxcbZW7sbqRFuotSptcpMuN6nwThJ8x2")
+
+        api.object.links(multihash) { result in
+            guard let node = try? result.get() else {
+                XCTFail()
+                return
+            }
+
+            // There should be two links off the root:
+            if let links = node.links, links.count == 2 {
+                XCTAssertEqual(b58String(links[0].hash!), "QmWfzntFwgPf9T9brQ6P2PL1BMoH16jZvhanGYtZQfgyaD")
+                XCTAssertEqual(b58String(links[1].hash!), "QmRJ8Gngb5PmvoYDNZLrY6KujKPa4HxtJEXNkb5ehKydg2")
+            } else {
+                XCTFail()
+            }
+            objLinksExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 50.0)
     }
-    
-    func testObject() {
-        
-        let objNewExpectation = XCTestExpectation(description: "testObjectNew")
-        let objPutExpectation = XCTestExpectation(description: "testObjectPut")
-        let objGetExpectation = XCTestExpectation(description: "testObjectGet")
-        let objLinksExpectation = XCTestExpectation(description: "testObjectLinks")
-        
-        do {
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.object.new() {
-                (result: MerkleNode) in
-                
-                /// A new ipfs object always has the same hash so we can assert against it.
-                XCTAssert(b58String(result.hash!) == "QmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n")
+
+    func testObjectPatch() throws {
+        let objNewExpectation = expectation(description: "testObjectNew")
+        let objPatchExpectation = expectation(description: "testObjectPatch")
+        let objLinksExpectation = expectation(description: "testObjectLinks")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+
+        // Get the empty directory object to start off with.
+        api.object.new { result in
+            let node = result.getOrNil()
+            XCTAssertNotNil(node)
+
+            let data = "This is a longer message."
+            api.object.patch(node!.hash!, cmd: .setData, args: data) { result in
                 objNewExpectation.fulfill()
-            }
 
-            
-            // Test Object Put
-            let data = [UInt8]("{ \"Data\" : \"Dauz\" }".utf8)
+                // The previous hash that was returned from setData
+                let previousMultihash = try? fromB58String("QmQXys2Xv5xiNBR21F1NNwqWC5cgHDnndKX4c3yXwP4ywj")
+                // Get the empty directory object to start off with.
 
-            try api.object.put(data) { (result: MerkleNode) in
+                let data = " Addition to the message."
+                api.object.patch(previousMultihash!, cmd: .appendData, args: data) { result in
+                    let node = result.getOrNil()
 
-                XCTAssert(b58String(result.hash!) == "QmUqvXbE4s9oTQNhBXm2hFapLq1pnuuxsMdxP9haTzivN6")
-                objPutExpectation.fulfill()
-            }
+                    // Now we request the data from the new Multihash to compare it.
+                    api.object.data(node!.hash!) { result in
+                        guard let bytes = result.getOrNil() else {
+                            XCTFail()
+                            return
+                        }
 
-            // Test Object Get
-            var multihash = try fromB58String("QmUqvXbE4s9oTQNhBXm2hFapLq1pnuuxsMdxP9haTzivN6")
+                        let resultString = String(bytes: bytes, encoding: .utf8)
+                        XCTAssertEqual(resultString, "This is a longer message. Addition to the message.")
 
-            try api.object.get(multihash) { (result: MerkleNode) in
+                        objPatchExpectation.fulfill()
 
-                XCTAssert(result.data! == Array("Dauz".utf8))
-                objGetExpectation.fulfill()
-            }
+                        let hash = "QmUYttJXpMQYvQk5DcX2owRUuYJBJM6W7KQSUsycCCE2MZ" // a file
+                        let hash2 = "QmVtU7ths96fMgZ8YSZAbKghyieq7AjxNdcqyVzxTt3qVe" // a directory
 
-            // Test Object Links
-            multihash = try fromB58String("QmR3azp3CCGEFGZxcbZW7sbqRFuotSptcpMuN6nwThJ8x2")
+                        // Get the empty directory object to start off with.
+                        api.object.new(.unixFsDir) { result in
+                            let node = result.getOrNil()
+                            XCTAssertNotNil(node)
 
-            try api.object.links(multihash) { (result: MerkleNode) in
+                            /** This uses the directory object to create a new object patched
+                             with the object of the given hash. */
+                            api.object.patch(node!.hash!, cmd: .addLink, args: "foo", hash) { result in
+                                let node = result.getOrNil()
+                                XCTAssertNotNil(node)
 
-                print(b58String(result.hash!))
-                /// There should be two links off the root:
-                if let links = result.links, links.count == 2 {
-                    let link1 = links[0]
-                    let link2 = links[1]
-                    XCTAssert(b58String(link1.hash!) == "QmWfzntFwgPf9T9brQ6P2PL1BMoH16jZvhanGYtZQfgyaD")
-                    XCTAssert(b58String(link2.hash!) == "QmRJ8Gngb5PmvoYDNZLrY6KujKPa4HxtJEXNkb5ehKydg2")
-                } else {
-                    XCTFail()
-                }
-                objLinksExpectation.fulfill()
+                                // Get a new object from the previous object patched with the object of hash2
+                                api.object.patch(node!.hash!, cmd: .addLink, args: "ars", hash2) { result in
+                                    let node = result.getOrNil()
 
-            }
+                                    // get the new object's links to check against.
+                                    api.object.links(node!.hash!) { result in
+                                        let node = result.getOrNil()
 
-        } catch {
-            XCTFail("test failed with error \(error)")
-        }
-        
-        wait(for: [objNewExpectation, objPutExpectation, objGetExpectation, objLinksExpectation], timeout: 50.0)
-    }
+                                        // Check that the object's link is the same as
+                                        // what we originally passed to the patch command.
 
-    func testObjectPatch() {
-        
-        let objNewExpectation = XCTestExpectation(description: "testObjectNew")
-        let objPatchExpectation = XCTestExpectation(description: "testObjectPatch")
-        let objLinksExpectation = XCTestExpectation(description: "testObjectLinks")
-        do {
-        
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            
-            /// Get the empty directory object to start off with.
-            try api.object.new() {
-                (result: MerkleNode) in
+                                        let links = node?.links
+                                        XCTAssertEqual(links?.count, 2)
+                                        XCTAssertNotNil(links)
 
-                let data = "This is a longer message."
-                try api.object.patch(result.hash!, cmd: .SetData, args: data) {
-                    result in
-                    
-                    print(b58String(result.hash!))
-                    
-                    objNewExpectation.fulfill()
-                    
-                    /// The previous hash that was returned from setData
-                    let previousMultihash = try fromB58String("QmQXys2Xv5xiNBR21F1NNwqWC5cgHDnndKX4c3yXwP4ywj")
-                    /// Get the empty directory object to start off with.
-                    
-                    let data = " Addition to the message."
-                    try api.object.patch(previousMultihash, cmd: .AppendData, args: data) {
-                        result in
-                        
-                        print(b58String(result.hash!))
-                        
-                        /// Now we request the data from the new Multihash to compare it.
-                        try api.object.data(result.hash!) {
-                            result in
-                            
-                            let resultString = String(bytes: result, encoding: String.Encoding.utf8)
-                            XCTAssert(resultString == "This is a longer message. Addition to the message.")
-                            
-                            objPatchExpectation.fulfill()
-                            
-                            let hash = "QmUYttJXpMQYvQk5DcX2owRUuYJBJM6W7KQSUsycCCE2MZ" /// a file
-                            let hash2 = "QmVtU7ths96fMgZ8YSZAbKghyieq7AjxNdcqyVzxTt3qVe" /// a directory
-                            
-                            /// Get the empty directory object to start off with.
-                            try? api.object.new(.UnixFsDir) {
-                                (result: MerkleNode) in
-                                
-                                /** This uses the directory object to create a new object patched
-                                 with the object of the given hash. */
-                                try? api.object.patch(result.hash!, cmd: IpfsObject.ObjectPatchCommand.AddLink, args: "foo", hash) {
-                                    (result: MerkleNode) in
-                                    
-                                    /// Get a new object from the previous object patched with the object of hash2
-                                    try? api.object.patch(result.hash!, cmd: IpfsObject.ObjectPatchCommand.AddLink, args: "ars", hash2) {
-                                        (result: MerkleNode) in
-                                        
-                                        /// get the new object's links to check against.
-                                        try? api.object.links(result.hash!) {
-                                            (result: MerkleNode) in
-                                            
-                                            /// Check that the object's link is the same as
-                                            /// what we originally passed to the patch command.
-                                            if let links = result.links, links.count == 2,
-                                                let linkHash = links[1].hash, b58String(linkHash) == hash {}
-                                            else { XCTFail() }
-                                            
-                                            /// Now try to remove it and check that we only have one link.
-                                            try? api.object.patch(result.hash!, cmd: .RmLink, args: "foo") {
-                                                (result: MerkleNode) in
-                                                
-                                                /// get the new object's links to check against.
-                                                try? api.object.links(result.hash!) {
-                                                    (result: MerkleNode) in
-                                                    
-                                                    if let links = result.links, links.count == 1,
-                                                        let linkHash = links[0].hash, b58String(linkHash) == hash2 {}
-                                                    else { XCTFail() }
-                                                    
-                                                    objLinksExpectation.fulfill()
+                                        guard let linkHash = links?[1].hash else {
+                                            XCTFail()
+                                            return
+                                        }
+                                        XCTAssertEqual(b58String(linkHash), hash)
+
+                                        // Now try to remove it and check that we only have one link.
+                                        api.object.patch(node!.hash!, cmd: .rmLink, args: "foo") { result in
+                                            let node = result.getOrNil()
+                                            XCTAssertNotNil(node)
+
+                                            // get the new object's links to check against.
+                                            api.object.links(node!.hash!) { result in
+                                                guard let links = result.getOrNil()?.links else {
+                                                    XCTFail()
+                                                    return
                                                 }
+
+                                                XCTAssertEqual(links.count, 1)
+
+                                                let linkHash = links[0].hash
+                                                XCTAssertNotNil(linkHash)
+                                                XCTAssertEqual(b58String(linkHash!), hash2)
+
+                                                objLinksExpectation.fulfill()
                                             }
                                         }
                                     }
                                 }
                             }
-
                         }
-                    }
 
+                    }
                 }
+
             }
-        } catch {
-            XCTFail("test failed with error \(error)")
         }
-        
-        wait(for: [objNewExpectation, objPatchExpectation, objLinksExpectation], timeout: 50.0)
+
+        waitForExpectations(timeout: 50.0)
     }
     
-    
-    func testNameResolve() {
-        
-        let nameResolveExpectation = XCTestExpectation(description: "testNameResolve")
-        let namePublishExpectation = XCTestExpectation(description: "testNamePublish")
-        let nameResolve2Expectation = XCTestExpectation(description: "testNameResolve2")
-        
-        do {
+    func testNameResolve() throws {
+        let nameResolveExpectation = expectation(description: "testNameResolve")
+        let namePublishExpectation = expectation(description: "testNamePublish")
+        let nameResolve2Expectation = expectation(description: "testNameResolve2")
 
-            var idHash: String = ""
-            /// Start test by storing the existing hash so we can restore it after testing.
+        var idHash: String = ""
+        // Start test by storing the existing hash so we can restore it after testing.
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.name.resolve() { result in
-                
-                idHash = result.replacingOccurrences(of: "/ipfs/", with: "")
-                
-                nameResolveExpectation.fulfill()
-                
-                let publishedPath = "/ipfs/" + idHash
-                do {
-                    //let multihash = try fromB58String(idHash)
-                    
-//                    try api.name.publish(hash: multihash) { result in
-                    try api.name.publish(ipfsPath: publishedPath) { result in
-                        
-                        XCTAssert(  (result.object?["Name"]?.string)! == self.nodeIdString &&
-                            (result.object?["Value"]?.string)! == publishedPath)
-                        
-                        namePublishExpectation.fulfill()
-                        
-                        try? api.name.resolve(){ result in
-                            XCTAssert(result == publishedPath)
-                            nameResolve2Expectation.fulfill()
-                        }
-                    }
-                } catch {
-                    XCTFail()
-                }
-
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        api.name.resolve { result in
+            guard let name = result.getOrNil() else {
+                XCTFail()
+                return
             }
-        } catch {
-            XCTFail("test failed with error \(error)")
+
+            idHash = name.replacingOccurrences(of: "/ipfs/", with: "")
+
+            nameResolveExpectation.fulfill()
+
+            let publishedPath = "/ipfs/" + idHash
+            api.name.publish(ipfsPath: publishedPath) { result in
+                let json = result.getOrNil()
+
+                XCTAssertEqual(json?.object?["Name"]?.string, self.nodeIdString)
+                XCTAssertEqual(json?.object?["Value"]?.string, publishedPath)
+
+                namePublishExpectation.fulfill()
+
+                api.name.resolve { result in
+                    let path = result.getOrNil()
+                    XCTAssertNotNil(path)
+
+                    XCTAssertEqual(path, publishedPath)
+                    nameResolve2Expectation.fulfill()
+                }
+            }
         }
-        
-        wait(for: [nameResolveExpectation, namePublishExpectation, nameResolve2Expectation], timeout: 250.0)
+
+        waitForExpectations(timeout: 250.0)
     }
     
     
@@ -424,7 +366,7 @@ class SwiftIpfsApiTests: XCTestCase {
 
         let expectation = XCTestExpectation(description: "testFindProvs")
         do {
-            /// Common
+            // Common
             let api = try IpfsApi(host: self.hostString, port: self.hostPort)
 
             let multihash = try fromB58String("QmUFtMrBHqdjTtbebsL6YGebvjShh3Jud1insUv12fEVdA")
@@ -449,613 +391,476 @@ class SwiftIpfsApiTests: XCTestCase {
     }
     
     // This test fails on timeout because the api doesn't actually end and thus doesn't return. Fix somehow.
-    func testDhtQuery() {
-        
-        let expectation = XCTestExpectation(description: "testDhtQuery")
-        do {
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            let neighbour = self.altNodeIdString
-            /// This nearest works for me but may need changing to something local to the tester.
-            let nearest = try fromB58String(neighbour)
-            try api.dht.query(nearest) {
-                result in
-                /// assert against some known return value
-                print(result)
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail("test failed with error \(error)")
-        }
-        
-        wait(for: [expectation], timeout: 120.0)
-    }
-    
-    func testDhtFindPeer() {
-        
-        let expectation = XCTestExpectation(description: "testDhtFindPeer")
-        do {
-            
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            let neighbour = self.altNodeIdString
-            /// This peer works for me but may need changing to something local to the tester.
-            let peer = try fromB58String(neighbour)
-            
-            /// At the moment the findpeer wraps the stream json in an array
-            try api.dht.findpeer(peer) {
-                result in
-                
-                var pass = false
-                
-                if let resArray = result.object?["Responses"]?.array {
-                    for res in resArray {
-                        if res.object?["ID"]?.string == neighbour {
-                            pass = true
-                        }
-                    }
-                }
-                XCTAssert(pass)
-                
-                expectation.fulfill()
-            }
-            
-        } catch {
-            XCTFail("test failed with error \(error)")
-        }
-        
-        wait(for: [expectation], timeout: 5.0)
-    }
-    
-    /// If this fails check from the command line that the ipns path actually resolves
-    /// to the checkHash before thinking this is actually broken. Ipns links do change.
-    func testFileLs() {
-                
-        let ipnsExpectation = XCTestExpectation(description: "testIpnsLs")
-        let ipfsExpectation = XCTestExpectation(description: "testIpfsLs")
-        
-        do {
+    func testDhtQuery() throws {
+        let completionExpectation = expectation(description: "testDhtQuery")
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            /// basedir hash
-            var path = "/ipns/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
-            
-            /// lvl2file hash
-            let checkIpnsHash = "QmV1imZz8VRiYFw7ZSSUtTFtcaYA5iJXURkxLhEJssBXvy"
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        let neighbour = altNodeIdString
 
-            try api.file.ls(path) { result in
-                
-                if let foundHash = result.object?["Objects"]?.object?[checkIpnsHash]?.object?["Hash"]?.string {
-                    
-                    XCTAssert(foundHash == checkIpnsHash)
-                } else { XCTFail() }
-                
-                ipnsExpectation.fulfill()
-            }
-            
-            let objHash = "QmQuQzFkULYToUBrMtyHg2tjvcd93N4kNHPCxfcFthB2kU"
-            let checkIpfsHash = "QmQHAVCpAQxU21bK8VxeWisn19RRC4bLNFV4DiyXDDyLXM"
-            path = "/ipfs/" + objHash
-            
-            try api.file.ls(path) { result in
-                
-                XCTAssert(result.object?["Objects"]?.object?[objHash]?.object?["Links"]?.array?[0].object?["Hash"]?.string == checkIpfsHash)
-                
-                ipfsExpectation.fulfill()
-            }
-        } catch {
-            XCTFail("testFileLs failed with error \(error)")
+        // This nearest works for me but may need changing to something local to the tester.
+        let nearest = try fromB58String(neighbour)
+
+        api.dht.query(nearest) { result in
+            // TODO: assert against some known return value
+            XCTAssertNotNil(result.getOrNil())
+            completionExpectation.fulfill()
         }
-        
-        wait(for: [ipnsExpectation, ipfsExpectation], timeout: 35.0)
+
+        waitForExpectations(timeout: 120.0)
     }
     
-    func testBootstrap() {
-        
+    func testDhtFindPeer() throws {
+        let completionExpectation = expectation(description: "testDhtFindPeer")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        let neighbour = altNodeIdString
+
+        // This peer works for me but may need changing to something local to the tester.
+        let peer = try fromB58String(neighbour)
+
+        // At the moment the findpeer wraps the stream json in an array
+        api.dht.findpeer(peer) { result in
+            guard
+                let json = result.getOrNil(),
+                let resArray = json.object?["Responses"]?.array else {
+                    XCTFail()
+                    return
+            }
+
+            for res in resArray {
+                XCTAssertEqual(res.object?["ID"]?.string, neighbour)
+            }
+
+            completionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0)
+    }
+    
+    // If this fails check from the command line that the ipns path actually resolves
+    // to the checkHash before thinking this is actually broken. Ipns links do change.
+    func testFileLs() throws {
+        let ipnsExpectation = expectation(description: "testIpnsLs")
+        let ipfsExpectation = expectation(description: "testIpfsLs")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        // basedir hash
+        var path = "/ipns/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
+
+        // lvl2file hash
+        let checkIpnsHash = "QmV1imZz8VRiYFw7ZSSUtTFtcaYA5iJXURkxLhEJssBXvy"
+
+        api.file.ls(path) { result in
+            let foundHash = result.getOrNil()?.object?["Objects"]?.object?[checkIpnsHash]?.object?["Hash"]?.string
+            XCTAssertNotNil(foundHash)
+
+            XCTAssertEqual(foundHash, checkIpnsHash)
+
+            ipnsExpectation.fulfill()
+        }
+
+        let objHash = "QmQuQzFkULYToUBrMtyHg2tjvcd93N4kNHPCxfcFthB2kU"
+        let checkIpfsHash = "QmQHAVCpAQxU21bK8VxeWisn19RRC4bLNFV4DiyXDDyLXM"
+        path = "/ipfs/" + objHash
+
+        api.file.ls(path) { result in
+            let hash = result.getOrNil()?.object?["Objects"]?.object?[objHash]?.object?["Links"]?.array?[0].object?["Hash"]?.string
+
+            XCTAssertNotNil(hash)
+            XCTAssertEqual(hash, checkIpfsHash)
+
+            ipfsExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 35.0)
+    }
+    
+    func testBootstrap() throws {
         let trustedPeer = "/ip4/104.131.131.82/tcp/4001/ipfs/QmaCpDMGvV2BGHeYERUEnRQAwe3N8SzbUtfsmvsqQLuvuJ"
         let trustedPeer2 = "/ip4/104.236.176.52/tcp/4001/ipfs/QmSoLnSGccFuZQJzRadHn95W2CrSFmZuTdDWP8HXaHca9z"
-    
-        let bootstrapRmExpectation = XCTestExpectation(description: "testBootstrapRm")
-        let bootstrapListExpectation = XCTestExpectation(description: "testBootstrapList")
-        let bootstrapAddExpectation = XCTestExpectation(description: "testBootstrapAdd")
-        
-        do {
-            let tpMultiaddr = try newMultiaddr(trustedPeer)
-            let tpMultiaddr2 = try newMultiaddr(trustedPeer2)
-            
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
 
-            let tPeers = [tpMultiaddr, tpMultiaddr2]
-            
-            try api.bootstrap.list() { (peers: [Multiaddr]) in
-                
-                for peer in peers {
-                    print(try peer.string())
-                }
-                bootstrapListExpectation.fulfill()
-            }
-            
-            try api.bootstrap.add(tPeers) { (peers: [Multiaddr]) in
-                
-                for peer in peers {
-                    print(try peer.string())
-                }
-                
-                if peers.count == 2 {
-                    let t1 = try peers[0].string() == trustedPeer
-                    let t2 = try peers[1].string() == trustedPeer2
-                    XCTAssert(t1 && t2)
-                } else { XCTFail() }
-                
-                bootstrapAddExpectation.fulfill()
-                
-                try api.bootstrap.rm(tPeers) { (peers: [Multiaddr]) in
-                    
-                    for peer in peers {
-                        print(try peer.string())
-                    }
-                    
-                    let a = try peers[0].string() == trustedPeer
-                    let b = try peers[1].string() == trustedPeer2
-                    XCTAssert(peers.count == 2 && a && b)
-                    
-                    bootstrapRmExpectation.fulfill()
-                }
-            }
+        let bootstrapRmExpectation = expectation(description: "testBootstrapRm")
+        let bootstrapListExpectation = expectation(description: "testBootstrapList")
+        let bootstrapAddExpectation = expectation(description: "testBootstrapAdd")
 
-        } catch {
-            XCTFail("testLog failed with error \(error)")
+        let tpMultiaddr = try newMultiaddr(trustedPeer)
+        let tpMultiaddr2 = try newMultiaddr(trustedPeer2)
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+
+        let tPeers = [tpMultiaddr, tpMultiaddr2]
+
+        api.bootstrap.list { peers in
+            XCTAssertNotNil(peers.getOrNil())
+            bootstrapListExpectation.fulfill()
         }
-        
-        wait(for: [bootstrapRmExpectation, bootstrapListExpectation, bootstrapAddExpectation], timeout: 5.0)
+
+        api.bootstrap.add(tPeers) { result in
+            let peers = result.getOrNil()
+            XCTAssertNotNil(peers)
+
+            XCTAssertEqual(peers?.count, 2)
+            XCTAssertEqual(try? peers?[0].string(), trustedPeer)
+            XCTAssertEqual(try? peers?[1].string(), trustedPeer2)
+
+            bootstrapAddExpectation.fulfill()
+
+            api.bootstrap.rm(tPeers) { result in
+                let peers = result.getOrNil()
+                XCTAssertNotNil(peers)
+
+                XCTAssertEqual(peers?.count, 2)
+                XCTAssertEqual(try? peers?[0].string(), trustedPeer)
+                XCTAssertEqual(try? peers?[1].string(), trustedPeer2)
+
+                bootstrapRmExpectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: 5.0)
     }
     
-    func testSwarmPeers() {
+    func testSwarmPeers() throws {
+        // NB: This test will require the user to change the knownPeer to a known peer.
+        let knownPeer = peerIPAddr + "/ipfs/" + altNodeIdString
         
-        /// NB: This test will require the user to change the knownPeer to a known peer.
-        let knownPeer = peerIPAddr+"/ipfs/"+self.altNodeIdString
-        
-        let expectation = XCTestExpectation(description: "testSwarmPeers")
-        do {
+        let completionExpectation = expectation(description: "testSwarmPeers")
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.swarm.peers(){ (peers: [Multiaddr]) in
-                
-                var pass = false
-                for peer in peers {
-                    pass = (try peer.string() == knownPeer)
-                    if pass { break }
-                }
-                
-                XCTAssert(pass)
-                expectation.fulfill()
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        api.swarm.peers { result in
+            guard let peers = try? result.get() else {
+                XCTFail()
+                return
             }
-        } catch {
-            XCTFail("testSwarmPeers failed with error \(error)")
+
+            XCTAssertTrue(peers.allSatisfy { (try? $0.string()) ?? "" == knownPeer })
+            completionExpectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 5.0)
+
+        waitForExpectations(timeout: 5.0)
     }
     
-    func testSwarmAddrs() {
-        
-        let expectation = XCTestExpectation(description: "testSwarmAddrs")
-        do {
+    func testSwarmAddrs() throws {
+        let completionExpectation = expectation(description: "testSwarmAddrs")
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.swarm.addrs(){ addrs in
+        let api = try IpfsApi(host: hostString, port: hostPort)
 
-                if let addr = addrs.object?[self.altNodeIdString]?.array?[0].string {
-                    XCTAssert(addr == self.peerIPAddr)
-                } else { XCTFail() }
-                
-                expectation.fulfill()
+        api.swarm.addrs { result in
+            guard
+                let addrs = try? result.get(),
+                let safeAdress = addrs.object?[self.altNodeIdString]?.array?[0].string else {
+                    XCTFail()
+                    return
             }
-        } catch {
-            XCTFail("testSwarmAddrs failed with error \(error)")
+
+            XCTAssertEqual(safeAdress, self.peerIPAddr)
+            completionExpectation.fulfill()
         }
         
-        wait(for: [expectation], timeout: 5.0)
+        waitForExpectations(timeout: 5.0)
     }
 
-    func testSwarmConnect() {
-        
-        let expectation = XCTestExpectation(description: "testSwarmConnect")
-        do {
+    func testSwarmConnect() throws {
+        let completionExpectation = expectation(description: "testSwarmConnect")
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            
-            /// NB: This test will require the user to change the peerAddress to a known peer.
-            let peerAddress = self.peerIPAddr+"/ipfs/"+self.altNodeIdString
-            let expectedMessage = "connect \(self.altNodeIdString) success"
-            
-            try api.swarm.connect(peerAddress){ result in
-                
-                if let msg = result.object?["Strings"]?.array?[0].string {
-                    XCTAssert(msg == expectedMessage)
-                } else { XCTFail() }
-                
-                // Not currently working as expected due to circuit relay implementation.
-                // see https://discuss.ipfs.io/t/ipfs-swarm-disconnect-failure-conn-not-found/2553/6
-                try api.swarm.disconnect(peerAddress) { result in
-                    
-                    if let msg = result.object?["Strings"]?.array?[0].string {
-                        XCTAssert(msg == "dis" + expectedMessage)
-                    } else { XCTFail() }
-                    
-                    expectation.fulfill()
-                }
+        let api = try IpfsApi(host: hostString, port: hostPort)
+
+        // NB: This test will require the user to change the peerAddress to a known peer.
+        let peerAddress =  peerIPAddr + "/ipfs/" + altNodeIdString
+        let expectedMessage = "connect \(altNodeIdString) success"
+
+        api.swarm.connect(peerAddress) { result in
+            let json = result.getOrNil()
+            XCTAssertNotNil(json)
+
+            let msg = json?.object?["Strings"]?.array?[0].string
+            XCTAssertNotNil(msg)
+            XCTAssertEqual(msg, expectedMessage)
+
+            // Not currently working as expected due to circuit relay implementation.
+            // see https://discuss.ipfs.io/t/ipfs-swarm-disconnect-failure-conn-not-found/2553/6
+            api.swarm.disconnect(peerAddress) { result in
+                let json = result.getOrNil()
+                XCTAssertNotNil(json)
+
+                let msg = json?.object?["Strings"]?.array?[0].string
+                XCTAssertNotNil(msg)
+                XCTAssertEqual(msg, "dis" + expectedMessage)
+
+                completionExpectation.fulfill()
             }
-        } catch {
-            XCTFail("testSwarmConnect failed with error \(error)")
+        }
+
+        waitForExpectations(timeout: 5.0)
+    }
+
+    func testDiag() throws {
+        let completionExpectation = expectation(description: "testDiagSys")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+
+        api.diag.sys() { result in
+            completionExpectation.fulfill()
         }
         
-        wait(for: [expectation], timeout: 5.0)
+        waitForExpectations(timeout: 5.0)
     }
     
-    
-    func testDiag() {
-        
-        let expectation = XCTestExpectation(description: "testDiagSys")
-        do {
+    func testConfig() throws {
+        let configShowExpectation = expectation(description: "testConfigShow")
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            
-            try api.diag.sys() {
-                result in
-                print("diag sys result: \(result)")
-                /// do comparison with truth here.
-                expectation.fulfill()
-            }
+        let api = try IpfsApi(host: hostString, port: hostPort)
 
-        } catch {
-            XCTFail("testDiag failed with error \(error)")
+        api.config.show() { result in
+            XCTAssertNotNil(result.getOrNil())
+
+            /// do comparison with truth here. Currently by visual inspection :/
+            configShowExpectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 5.0)
-    }
-    
-    func testConfig() {
-        
-        do {
-            let configShowExpectation = XCTestExpectation(description: "testConfigShow")
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            
-            try api.config.show() {
-                result in
-                print(result)
-                /// do comparison with truth here. Currently by visual inspection :/
-                configShowExpectation.fulfill()
-            }
 
-            let configSetExpectation = XCTestExpectation(description: "testConfigSet")
-            let configSetGetExpectation = XCTestExpectation(description: "setGetExpectation")
-            
-            // Set a value in the config and read back the same to confirm.
-            try api.config.set("Teo", value: "42") {
-                result in
-                
-                configSetExpectation.fulfill()
-                
-                try api.config.get("Teo") {
-                    result in
-                    
-                    if let strValue = result.string {
-                        XCTAssertTrue(strValue == "42")
-                    } else {  XCTFail() }
-                    
-                    configSetGetExpectation.fulfill()
-                }
-                
-            }
-            
-            wait(for: [configShowExpectation, configSetExpectation, configSetGetExpectation], timeout: 25.0)
+        let configSetExpectation = expectation(description: "testConfigSet")
+        let configSetGetExpectation = expectation(description: "setGetExpectation")
 
-        } catch {
-            XCTFail("testConfig failed with error \(error)")
+        // Set a value in the config and read back the same to confirm.
+        api.config.set("Teo", value: "42") { result in
+            configSetExpectation.fulfill()
+
+            api.config.get("Teo") { result in
+                let json = result.getOrNil()
+                XCTAssertNotNil(json)
+
+                XCTAssertEqual(json?.string, "42")
+
+                configSetGetExpectation.fulfill()
+            }
         }
+
+        waitForExpectations(timeout: 25.0)
     }
     
     
-    func testLs() {
-        
-        let expectation = XCTestExpectation(description: "testLs")
-        do {
-            let multihash = try fromB58String("QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT")
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.ls(multihash) {
-                results in
-                
-                
-                let node = results[0]
-                if let links = node.links {
-                    let pass = (links.count == 5 &&
-                        links[0].name! == "contact" &&
-                        links[1].name! == "help" &&
-                        links[2].name! == "quick-start" &&
-                        links[3].name! == "readme" &&
-                        links[4].name! == "security-notes")
-                    
-                    XCTAssertTrue(pass)
-                } else {
-                    XCTFail("testLs no links found.")
-                }
-                
-                expectation.fulfill()
+    func testLs() throws {
+        let completionExpectation = expectation(description: "testLs")
+
+        let multihash = try fromB58String("QmPXME1oRtoT627YKaDPDQ3PwA8tdP9rWuAAweLzqSwAWT")
+        let api = try IpfsApi(host: self.hostString, port: self.hostPort)
+        api.ls(multihash) { results in
+            guard
+                let nodes = try? results.get(),
+                let links = nodes.first?.links else {
+                    XCTFail()
+                    return
             }
-        } catch {
-            XCTFail("testLs failed with error \(error)")
+
+            XCTAssertEqual(links.count, 5)
+            XCTAssertEqual(links[0].name, "contact")
+            XCTAssertEqual(links[1].name, "help")
+            XCTAssertEqual(links[2].name, "quick-start")
+            XCTAssertEqual(links[3].name, "readme")
+            XCTAssertEqual(links[4].name, "security-notes")
+
+            completionExpectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 5.0)
+
+        waitForExpectations(timeout: 5.0)
     }
         
-    func testCat() {
+    func testCat() throws {
+        let completionExpectation = XCTestExpectation(description: "testCat")
 
-        let expectation = XCTestExpectation(description: "testCat")
-        do {
+        let multihash = try fromB58String("QmYeQA5P2YuCKxZfSbjhiEGD3NAnwtdwLL6evFoVgX1ULQ")
+        let api = try IpfsApi(host: hostString, port: hostPort)
 
-            let multihash = try fromB58String("QmYeQA5P2YuCKxZfSbjhiEGD3NAnwtdwLL6evFoVgX1ULQ")
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            
-            try api.cat(multihash) {
-                result in
-                print("cat:",String(bytes: result, encoding: String.Encoding.utf8)!)
-                
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail("testCat failed with error \(error)")
+        api.cat(multihash) { _ in
+            completionExpectation.fulfill()
         }
         
-        wait(for: [expectation], timeout: 5.0)
+        waitForExpectations(timeout: 5.0)
     }
 
-    func testPing() {
-        
-        let expectation = XCTestExpectation(description: "testPing")
-        do {
+    func testPing() throws {
+        let completionExpectation = expectation(description: "testPing")
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.ping(self.altNodeIdString) {
-               result in
-                
-                if let pings = result.array {
-                    for ping in pings {
-                        print(ping.object?["Text"] ?? "-")
-                        print(ping.object?["Time"] ?? "-")
-                        print(ping.object?["Success"] ?? "-")
-                    }
-                }
+        let api = try IpfsApi(host: hostString, port: hostPort)
 
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail("testPing failed with error \(error)")
+        api.ping(altNodeIdString) { result in
+            completionExpectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 15.0)
+
+        waitForExpectations(timeout: 15.0)
     }
     
-    func testIds() {
-        
-        let idt1Expectation = XCTestExpectation(description: "testIds 1")
-        let idt2Expectation = XCTestExpectation(description: "testIds 2")
-        
-        do {
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            let idString = self.nodeIdString
-            
-            try api.id(idString) { result in
-                
-                XCTAssert(result.object?[IpfsCmdString.ID.rawValue]?.string == idString)
-                
-                idt1Expectation.fulfill()
-            }
-        
-            
-            try api.id() {
-                result in
-                
-                XCTAssert(result.object?["ID"]?.string == idString)
-                idt2Expectation.fulfill()
-            }
-            
-        } catch {
-            XCTFail("testIds failed with error \(error)")
+    func testIds() throws {
+        let idt1Expectation = expectation(description: "testIds 1")
+        let idt2Expectation = expectation(description: "testIds 2")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        let idString = nodeIdString
+
+        api.id(idString) { result in
+            let json = result.getOrNil()
+            XCTAssertNotNil(json)
+
+            XCTAssertEqual(json?.object?[IpfsCmdString.ID.rawValue]?.string, idString)
+
+            idt1Expectation.fulfill()
         }
-        
-        wait(for: [idt1Expectation, idt2Expectation], timeout: 15.0)
+
+        api.id { result in
+            let json = result.getOrNil()
+            XCTAssertNotNil(json)
+
+            XCTAssertEqual(json?.object?["ID"]?.string, idString)
+            idt2Expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 15.0)
     }
     
     
-    func testVersion() {
-        
-        let expectation = XCTestExpectation(description: "testVersion")
-        do {
+    func testVersion() throws {
+        let completionExpectation = expectation(description: "testVersion")
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.version() { version in
-                
-                XCTAssert(version == self.currentIpfsVersion)
-                
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail("testVersion failed with error \(error)")
-        }
-        
-        wait(for: [expectation], timeout: 5.0)
-    }
-    
-    func testCommands() {
-        
-        let expectation = XCTestExpectation(description: "testCommands")
-        do {
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        api.version { result in
+            let version = result.getOrNil()
+            XCTAssertNotNil(version)
 
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.commands(true) {
-                result in
-               
-                // Short of having a gigantic (and regularly changing) table to
-                // check against I don't know how to verify this. For now a
-                // visual inspection will have to do.
-                if let commands = result.object {
-                    for (k,v) in commands {
-                        print("k: ",k)
-                        print("v: ",v)
-                    }
-                }
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail("testCommands failed with error \(error)")
+            XCTAssertEqual(version, self.currentIpfsVersion)
+            completionExpectation.fulfill()
         }
-        
-        wait(for: [expectation], timeout: 5.0)
-    }
-    
-    func testStats() {
 
-        let expectation = XCTestExpectation(description: "testStats")
-        do {
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            try api.stats.bw() { result in
-               
-                /// We can't check for the values as they change constantly but at 
-                /// least we can check for the keys being there.
-                XCTAssert(result.object?["TotalIn"] != nil &&
-                    result.object?["TotalOut"] != nil &&
-                    result.object?["RateIn"] != nil &&
-                    result.object?["RateOut"] != nil )
-                
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail("testStats failed with error \(error)")
-        }
-    
-        wait(for: [expectation], timeout: 5.0)
+        waitForExpectations(timeout: 5.0)
     }
     
-    func testLog() {
-        
-        let expectation = XCTestExpectation(description: "testLog")
-        do {
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            let updateHandler = { (data: Data) -> Bool in
-                print("Got an update. Closing.")
-                return false
+    func testCommands() throws {
+        let completionExpectation = expectation(description: "testCommands")
+
+            let api = try IpfsApi(host: hostString, port: hostPort)
+            api.commands(true) { result in
+                XCTAssertNotNil(result.getOrNil())
+                completionExpectation.fulfill()
             }
-            
-            try api.log(updateHandler) {
-                log in
-                
-                for entry in log {
-                    print(entry)
-                }
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail("testLog failed with error \(error)")
-        }
-        
-        wait(for: [expectation], timeout: 5.0)
+
+        waitForExpectations(timeout: 5.0)
     }
     
-    func testdns() {
-        
-        let expectation = XCTestExpectation(description: "testdns")
-        
-        do {
-            let api       = try IpfsApi(addr: "/ip4/\(self.hostString)/tcp/\(self.hostPort)")
-            let domain    = "ipfs.io"
+    func testStats() throws {
+        let completionExpectation = expectation(description: "testStats")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+
+        api.stats.bw { result in
+            /// We can't check for the values as they change constantly but at
+            /// least we can check for the keys being there.
+
+            let json = result.getOrNil()
+            XCTAssertNotNil(json)
+            XCTAssertNotNil(json?.object?["TotalIn"])
+            XCTAssertNotNil(json?.object?["TotalOut"])
+            XCTAssertNotNil(json?.object?["RateIn"])
+            XCTAssertNotNil(json?.object?["RateOut"])
+
+            completionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 5.0)
+    }
+    
+    func testLog() throws {
+        let completionExpectation = expectation(description: "testLog")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        let updateHandler = { (data: Data) -> Bool in
+            return false
+        }
+
+        try api.log(updateHandler) { log in
+            completionExpectation.fulfill()
+        }
+        waitForExpectations(timeout: 5.0)
+    }
+    
+    func testdns() throws {
+        let completionExpectation = expectation(description: "testdns")
+
+            let api = try IpfsApi(addr: "/ip4/\(hostString)/tcp/\(hostPort)")
+            let domain = "ipfs.io"
+
             // Change domainHash to match whatever the actual hash of ipfs.io currently resolves to.
             let domainHash = "QmYNQJoKGNHTpPxCBPh9KkDpaExgd2duMa3aF6ytMpHdao"
             
-            try api.dns(domain) { domainString in
-                
-                print("Domain: ",domainString)
-                XCTAssert(domainString == "/ipfs/\(domainHash)")
+            api.dns(domain) { result in
+                let domainString = result.getOrNil()
+                XCTAssertNotNil(domainString)
 
-                expectation.fulfill()
+                XCTAssertEqual(domainString, "/ipfs/\(domainHash)")
+                completionExpectation.fulfill()
             }
-        } catch {
-            XCTFail("testdns failed with error \(error)")
-        }
-    
-        wait(for: [expectation], timeout: 120.0)
-    }
-    
-    func testMount() {
-        
-        let expectation = XCTestExpectation(description: "testMount")
 
-        do {
-            let api       = try IpfsApi(addr: "/ip4/\(self.hostString)/tcp/\(self.hostPort)")
-            
-            try api.mount() {
-                result in
-                
-                print("Mount got", result)
-                XCTAssert(  result.object?["IPFS"]?.string == "/ipfs" &&
-                            result.object?["IPNS"]?.string == "/ipns")
-                expectation.fulfill()
-            }
-            
-        } catch {
-            XCTFail("testMount failed with error \(error)")
-        }
-        
-        wait(for: [expectation], timeout: 120.0)
+        waitForExpectations(timeout: 120.0)
     }
     
-    func testResolveIpfs() {
-        
-        let expectation = XCTestExpectation(description: "testResolveIpfs")
-        do {
-            let api       = try IpfsApi(addr: "/ip4/\(self.hostString)/tcp/\(self.hostPort)")
-            let multihash = try fromB58String("QmeZy1fGbwgVSrqbfh9fKQrAWgeyRnj7h8fsHS1oy3k99x")
-            
-            try api.resolve("ipfs", hash: multihash, recursive: false) { result in
-                
-				XCTAssert(result.object?["Path"]?.string == "/ipfs/QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ")
-                
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail()
-        }
-        
-        wait(for: [expectation], timeout: 120.0)
-    }
-    
-    func testResolveIpns() {
-        
-        let expectation = XCTestExpectation(description: "testResolveIpns")
-        do {
-            let api       = try IpfsApi(addr: "/ip4/\(self.hostString)/tcp/\(self.hostPort)")
-            let multihash = try fromB58String(self.nodeIdString)
-            
-            try api.resolve("ipns", hash: multihash, recursive: false) {
-                result in
-                
-                // Replace the resolved string for your own.
-                let resolvedIpnsString = "/ipfs/QmeVYFFc4gDmBkNB44RykvunsUFK777iYN1SH1J1VFYn15"
-                
-                XCTAssert(result.object?["Path"]?.string == resolvedIpnsString)
-                
-                expectation.fulfill()
-            }
-        } catch {
-            XCTFail()
-            print("Error in testResolveIpns \(error)")
-        }
-        wait(for: [expectation], timeout: 120.0)
-    }
-    
+    func testMount() throws {
+        let completionExpectation = expectation(description: "testMount")
 
+        let api = try IpfsApi(addr: "/ip4/\(hostString)/tcp/\(hostPort)")
+
+        api.mount { result in
+            let json = result.getOrNil()
+            XCTAssertNotNil(json)
+
+            XCTAssertEqual(json?.object?["IPFS"]?.string, "/ipfs")
+            XCTAssertEqual(json?.object?["IPNS"]?.string, "/ipns")
+
+            completionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 120.0)
+    }
     
+    func testResolveIpfs() throws {
+        let completionExpectation = expectation(description: "testResolveIpfs")
+
+        let api = try IpfsApi(addr: "/ip4/\(hostString)/tcp/\(hostPort)")
+        let multihash = try fromB58String("QmeZy1fGbwgVSrqbfh9fKQrAWgeyRnj7h8fsHS1oy3k99x")
+
+        api.resolve("ipfs", hash: multihash, recursive: false) { result in
+            guard let json = try? result.get() else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertEqual(json.object?["Path"]?.string, "QmW2WQi7j6c7UgJTarActp7tDNikE4B2qXtFCfLPdsgaTQ")
+            completionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 120.0)
+    }
     
-    func testAdd() {
+    func testResolveIpns() throws {
+        let completionExpectation = expectation(description: "testResolveIpns")
+
+        let api = try IpfsApi(addr: "/ip4/\(hostString)/tcp/\(hostPort)")
+        let multihash = try fromB58String(nodeIdString)
+
+        api.resolve("ipns", hash: multihash, recursive: false) { result in
+            guard let json = try? result.get() else {
+                XCTFail()
+                return
+            }
+
+            // Replace the resolved string for your own.
+            let resolvedIpnsString = "/ipfs/QmeVYFFc4gDmBkNB44RykvunsUFK777iYN1SH1J1VFYn15"
+            XCTAssertEqual(json.object?["Path"]?.string, resolvedIpnsString)
+
+            completionExpectation.fulfill()
+        }
+
+        waitForExpectations(timeout: 120.0)
+    }
+    
+    func testAdd() throws {
 
 //            let filePaths = [   "file:///Users/teo/tmp/outstream.txt",
 //                                "file:///Users/teo/tmp/notred.png",
@@ -1065,117 +870,96 @@ class SwiftIpfsApiTests: XCTestCase {
                                 "file:///Users/teo/tmp/addtest5" : "Qma97dios2R9rndBXyzfVmYEaCF8hkcyA6ULnw4WLu8Yk6"]
 //            let filePaths = [   "file:///Users/teo/tmp/addtest5"]
 
-        var testExpectations = [XCTestExpectation]()
-        
-        do {
-            
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            
-            for pathToHash in pathsToHashes {
-        
-                let expectation = XCTestExpectation(description: pathToHash.key)
-                testExpectations.append(expectation)
-                
-                try api.add(pathToHash.key) {
-                    result in
-                    
-                    /// Subtract one because last element is an empty directory to ignore
-                    let resultCount = result.count
-                    
-                    for i in 0..<resultCount {
-                        
-                        print("Name: \(String(describing: result[i].name)) Hash:", b58String(result[i].hash!))
-                        
-                        if let hash = result[i].hash, b58String(hash) == pathToHash.value {
-                            expectation.fulfill()
-                            return
-                        }
-                    }
-                    
-                    // Did not find a match after going through all hashes in the result.
-                    expectation.fulfill()
+        let api = try IpfsApi(host: hostString, port: hostPort)
+
+        for pathToHash in pathsToHashes {
+            let completionExpectation = expectation(description: pathToHash.key)
+
+            api.add(pathToHash.key) { result in
+                guard let nodes = result.getOrNil() else {
                     XCTFail()
+                    return
+                }
+
+                // Subtract one because last element is an empty directory to ignore
+                for i in 0..<nodes.count {
+                    if let hash = nodes[i].hash, b58String(hash) == pathToHash.value {
+                        completionExpectation.fulfill()
+                        return
+                    }
                 }
             }
-        } catch {
-            print("Error in testAdd: \(error)")
         }
-        
-        wait(for: testExpectations, timeout: 60.0)
+
+        waitForExpectations(timeout: 60.0)
     }
     
-    func testAddData() {
-        
+    func testAddData() throws {
         let content = "Awesome file content"
         let contentHash = "QmQKqsRQYuiEzAwxfZxppGBsN8knJAGvVSV3GhnrTrLpzm"
         let fileData = content.data(using: .utf8)
-        let expectation = XCTestExpectation(description: "testAddData")
+        let completionExpectation = expectation(description: "testAddData")
+
+        let api = try IpfsApi(host: hostString, port: hostPort)
         
-        do {
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
+        api.add(fileData!) { result in
+            let nodes = result.getOrNil()
+            XCTAssertNotNil(nodes)
+            XCTAssertEqual(nodes?.count, 1)
+
+            guard let hash = nodes?.first?.hash else {
+                XCTFail()
+                return
+            }
+
+            XCTAssertEqual(b58String(hash), contentHash)
             
-            try api.add(fileData!) { result in
-                
-                guard result.count == 1, let hash = result[0].hash else {
+            api.cat(hash) { result in
+                guard let bytes = result.getOrNil() else {
                     XCTFail()
-                    expectation.fulfill()
                     return
                 }
+
+                let ipfsContent = String(bytes: bytes, encoding: .utf8)!
+                XCTAssertEqual(ipfsContent, content)
                 
-                XCTAssert(b58String(hash) == contentHash)
-                
-                try? api.cat(hash) { result in
-                    
-                    let ipfsContent = String(bytes: result, encoding: String.Encoding.utf8)!
-                    
-                    XCTAssert(ipfsContent == content)
-                    
-                    expectation.fulfill()
-                }
+                completionExpectation.fulfill()
             }
-            
-            wait(for: [expectation], timeout: 5.0)
-        } catch {
-            print("Error in testAddData \(error)")
         }
+        
+        waitForExpectations(timeout: 5.0)
     }
     
-    func testRefs() {
-        do {
-            let multihash = try fromB58String("QmXsnbVWHNnLk3QGfzGCMy1J9GReWN7crPvY1DKmFdyypK")
-            let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-            let expectation = XCTestExpectation(description: "testRefs")
-            
-            try api.refs(multihash, recursive: false) {
-                result in
-                
-                XCTAssert(  result.count == 2 &&
-                            b58String(result[0]) == "QmZX6Wrte3EqkUCwLHqBbuDhmH5yqPurNNTxKQc4NFfDxT" &&
-                            b58String(result[1]) == "QmaLB324wDRKEJbGGr8FWg3qWnpTxdc2oEKDT62qhe8tMR" )
-                
-                expectation.fulfill()
+    func testRefs() throws {
+        let multihash = try fromB58String("QmXsnbVWHNnLk3QGfzGCMy1J9GReWN7crPvY1DKmFdyypK")
+        let api = try IpfsApi(host: hostString, port: hostPort)
+        let completionExpectation = expectation(description: "testRefs")
+
+        api.refs(multihash, recursive: false) { result in
+            guard let hashes = result.getOrNil() else {
+                XCTFail()
+                return
             }
-            
-            wait(for: [expectation], timeout: 5.0)
-        } catch {
-            print("Error testRefs \(error)")
+
+            XCTAssertEqual(hashes.count, 2)
+            XCTAssertEqual(b58String(hashes[0]), "QmZX6Wrte3EqkUCwLHqBbuDhmH5yqPurNNTxKQc4NFfDxT")
+            XCTAssertEqual(b58String(hashes[1]), "QmaLB324wDRKEJbGGr8FWg3qWnpTxdc2oEKDT62qhe8tMR")
+
+            completionExpectation.fulfill()
         }
+
+        waitForExpectations(timeout: 5.0)
     }
-    
-    
-    
-    /// Utility functions
+
+    // MARK: - Utility functions
     
     func tester(_ test: (_ dispatchGroup: DispatchGroup) throws -> Void) {
-        
         let group = DispatchGroup()
         
         group.enter()
         
         do {
-            /// Perform the test.
             try test(group)
-            
         } catch  {
             XCTFail("tester error: \(error)")
         }
@@ -1183,31 +967,10 @@ class SwiftIpfsApiTests: XCTestCase {
         _ = group.wait(timeout: DispatchTime.distantFuture)
     }
     
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
-        self.measure {
-            // Put the code you want to measure the time of here.
-        }
-    }
-    
 }
-/** Template for test
-do {
-    let group = dispatch_group_create()
-    dispatch_group_enter(group)
 
-    let api = try IpfsApi(host: self.hostString, port: self.hostPort)
-    let multihash = try fromB58String("QmWPmgXnRn81QMPpfRGQ9ttQXsgfe2YwQxJ9PEB99E6KJh")
-
-    try api.??(??) {
-        result in
-        print("Bingo")
-
-        dispatch_group_leave(group)
+extension Result {
+    func getOrNil() -> Success? {
+        return try? self.get()
     }
-    dispatch_group_wait(group, DISPATCH_TIME_FOREVER)
-} catch {
-    print("TestBaseCommands error: ",error)
-    XCTFail()
 }
-*/


### PR DESCRIPTION
Hi there,

as it has been some time already since Swift 5 has been released, I took the freedom to migrate the codebase to Swift 5 and utilizing new features such as the newly introduced `Result` type as well as removing compiler warnings and unblocking ourselves from adding more improvements and making maintaining easier.

More importantly, I took this an opportunity of starting to clean up the codebase. While I spent a significant amount of time adjusting the tests for the changes I made and trying to improve the overall style by using proper asserts, I think I'll come back in a later PR to refactor the tests to use stubbing.